### PR TITLE
Updating ascii parsing

### DIFF
--- a/Sources/XCLogParser/loglocation/LogLoader.swift
+++ b/Sources/XCLogParser/loglocation/LogLoader.swift
@@ -33,10 +33,10 @@ public struct LogLoader {
                 else {
                     return nil
                 }
-                
+
                 return String(cString: charPointer, encoding: .ascii)
             }
-                        
+
             guard let contents = string else {
                 throw LogError.readingFile(url.path)
             }

--- a/Sources/XCLogParser/loglocation/LogLoader.swift
+++ b/Sources/XCLogParser/loglocation/LogLoader.swift
@@ -26,7 +26,18 @@ public struct LogLoader {
         do {
             let data = try Data(contentsOf: url)
             let unzipped = try data.gunzipped()
-            guard let contents =  String(data: unzipped, encoding: .ascii) else {
+            let string: String? = unzipped.withUnsafeBytes { pointer in
+                guard let charPointer = pointer
+                    .assumingMemoryBound(to: CChar.self)
+                    .baseAddress
+                else {
+                    return nil
+                }
+                
+                return String(cString: charPointer, encoding: .ascii)
+            }
+                        
+            guard let contents = string else {
                 throw LogError.readingFile(url.path)
             }
             return contents


### PR DESCRIPTION


## Description

Adding ascii encoding fix to `LogParser`

## Context / Why are we making this change?

For the Cortex CLI tool we are building we need to read `xcactivitylog` files, for some reason the latest version of XCLogParser fails to read the files produced by Xcode 16 when using the Swift Package.

This [PR](https://github.com/MobileNativeFoundation/XCLogParser/pull/217) from the main repo fixes it but hasn't been merged yet.